### PR TITLE
Complimentary for GameServer/pull/1462

### DIFF
--- a/LeaguePackets/Game/033_NPC_Die_EventHistory.cs
+++ b/LeaguePackets/Game/033_NPC_Die_EventHistory.cs
@@ -35,8 +35,10 @@ namespace LeaguePackets.Game
             writer.WriteUInt32(KillerNetID);
             writer.WriteFloat(Duration);
             writer.WriteInt32(Entries.Count);
-            foreach (var ev in Entries)
+            //foreach (var ev in Entries)
+            for (int i = Entries.Count - 1; i >= 0; i--)
             {
+                var ev = Entries[i];
                 writer.WriteEventHistoryEntry(ev);
             }
         }

--- a/LeaguePackets/Game/Events/ArgsBuff.cs
+++ b/LeaguePackets/Game/Events/ArgsBuff.cs
@@ -2,17 +2,8 @@
 
 namespace LeaguePackets.Game.Events
 {
-    public class ArgsBuff : ArgsBase
+    public class ArgsBuff : ArgsForClient
     {
-        public uint ScriptNameHash { get; set; }
-        public byte EventSource { get; set; }
-        // FIXME: new byte appeared here
-        public byte Unknown { get; set; }
-        public uint SourceObjectNetID { get; set; }
-        public uint ParentScriptNameHash { get; set; }
-        public uint ParentCasterNetID { get; set; }
-        public ushort Bitfield { get; set; }
-
         public override void ReadArgs(ByteReader reader)
         {
             base.ReadArgs(reader);

--- a/LeaguePackets/Game/Events/ArgsDamage.cs
+++ b/LeaguePackets/Game/Events/ArgsDamage.cs
@@ -2,19 +2,11 @@
 
 namespace LeaguePackets.Game.Events
 {
-    public class ArgsDamage: ArgsBase
+    public class ArgsDamage: ArgsForClient
     {
-        public uint ScriptNameHash { get; set; }
-        public byte EventSource { get; set; }
-        // FIXME: new byte or EventSource bigger ?
-        public byte Unknown { get; set; }
-        public uint SourceObjectNetID { get; set; }
         public float PhysicalDamage { get; set; }
         public float MagicalDamage { get; set; }
         public float TrueDamage { get; set; }
-        public uint ParentScriptNameHash { get; set; }
-        public uint ParentCasterNetID { get; set; }
-        public ushort Bitfield { get; set; }
         public override void ReadArgs(ByteReader reader)
         {
             base.ReadArgs(reader);

--- a/LeaguePackets/Game/Events/ArgsForClient.cs
+++ b/LeaguePackets/Game/Events/ArgsForClient.cs
@@ -1,0 +1,14 @@
+namespace LeaguePackets.Game.Events
+{
+    public abstract class ArgsForClient: ArgsBase
+    {
+        public uint ScriptNameHash { get; set; }
+        public byte EventSource { get; set; }
+        // FIXME: new byte appeared here
+        public byte Unknown { get; set; }
+        public uint SourceObjectNetID { get; set; }
+        public uint ParentScriptNameHash { get; set; }
+        public uint ParentCasterNetID { get; set; }
+        public ushort Bitfield { get; set; }
+    }
+}

--- a/LeaguePackets/Game/Events/ArgsHeal.cs
+++ b/LeaguePackets/Game/Events/ArgsHeal.cs
@@ -2,17 +2,9 @@
 
 namespace LeaguePackets.Game.Events
 {
-    public class ArgsHeal : ArgsBase
+    public class ArgsHeal : ArgsForClient
     {
-        public uint ScriptNameHash { get; set; }
-        public byte EventSource { get; set; }
-        // FIXME: new byte or EventSource bigger?
-        public byte Unknown { get; set; }
-        public uint SourceObjectNetID { get; set; }
         public float HealAmmount { get; set; }
-        public uint ParentScriptNameHash { get; set; }
-        public uint ParentCasterNetID { get; set; }
-        public ushort Bitfield { get; set; }
         public override void ReadArgs(ByteReader reader)
         {
             base.ReadArgs(reader);


### PR DESCRIPTION
- Moved common fields for `ArgsBuff`, `ArgsHeal` and `ArgsDamage` to `ArgsForClient`
- `NPC_Die_EventHistory` now writes events in reverse order (because in replays they are not in chronological order, and it is expensive to reverse the array before sending)